### PR TITLE
makefile: macOS compatible install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install: install-bins
 install-bins: bins
 	$(cmd_STRIP) $(BINS)
 	$(Q)[ -d "$(DESTDIR)$(PREFIX)/bin/." ] || mkdir -p -m 0755 $(DESTDIR)$(PREFIX)/bin
-	$(cmd_INSTALL) -m 0755 -t $(DESTDIR)$(PREFIX)/bin $(BINS)
+	$(cmd_INSTALL) -m 0755 $(BINS) $(DESTDIR)$(PREFIX)/bin 
 
 clean:
 	$(Q)-rm -f $(BINS) $(OBJS) *.o *~


### PR DESCRIPTION
`make install` fails on macOS due to a non-GNU version of `install` command.
```sh
jakub@jakub-mbp :: 23:43:56 :: ~/dev/heap/bootterm 
$ make
  CC      src/bt.o
  LD      bin/bt
rm src/bt.o
jakub@jakub-mbp :: 23:43:57 :: ~/dev/heap/bootterm 
$ make install
  STRIP   install-bins
  INSTALL install-bins
install: illegal option -- t
usage: install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 file2
       install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 ... fileN directory
       install -d [-v] [-g group] [-m mode] [-o owner] directory ...
make: *** [install-bins] Error 64
```

Fix applied:
```sh
jakub@jakub-mbp :: 23:50:44 :: ~/dev/heap/bootterm 
$ make
  CC      src/bt.o
m  LD      bin/bt
rm src/bt.o
jakub@jakub-mbp :: 23:50:46 :: ~/dev/heap/bootterm 
$ make install
  STRIP   install-bins
  INSTALL install-bins
```

I hope this doesn't cause any issues on other *nix systems.