### PR TITLE
Log error and die when failing to restore terminal after flashing

### DIFF
--- a/src/bt.c
+++ b/src/bt.c
@@ -1998,7 +1998,9 @@ void forward(int fd)
 
 	if (stdio_is_term && term_flashing) {
 		/* restore the terminal now */
-		write(1, "\e[?5l", 5);
+		if(write(1, "\e[?5l", 5) < 0) {
+			die(5, "Failed to restore terminal after flashing");
+		}
 	}
 
 	if (stdio_is_term) {

--- a/src/bt.c
+++ b/src/bt.c
@@ -1779,6 +1779,7 @@ void forward(int fd)
 	int term_flashing = 0;
 	int in_utf8 = 0;
 	int in_esc = 0;
+	int err = 0;
 
 	if (isatty(0) && isatty(1)) {
 		struct termios tio;
@@ -1999,16 +2000,20 @@ void forward(int fd)
 	if (stdio_is_term && term_flashing) {
 		/* restore the terminal now */
 		if(write(1, "\e[?5l", 5) < 0) {
-			die(5, "Failed to restore terminal after flashing");
+			err = 1;
 		}
 	}
 
 	if (stdio_is_term) {
 		/* restore settings and skip current line */
-		if (tcsetattr(0, TCSANOW, &tio_bck) != 0)
-			die(4, "Failed to restore stdio settings. Try 'stty sane'\n");
+		if (tcsetattr(0, TCSANOW, &tio_bck) != 0) {
+			err = 1;
+		}
 		putchar('\n');
 	}
+
+	if (err)
+		die(4, "Failed to restore stdio settings. Try 'stty sane'\n");
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Hi,
I observed a small warning when installing bootterm on Archlinux. The package is currently pointing to your tag 0.4. The warning does not seem to appear with a mere `make`, but it can be reproduced when trying to build it with the default CFLAGS from `makepkg` configuration (can be found in `/etc/makepkg.conf`). On my machine, I get the warning by running the following build command : 
```sh
➜  bootterm git:(2d50ab5) ✗ make V=1 CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection"
cc -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -o src/bt.o -c src/bt.c
src/bt.c: In function ‘forward’:
src/bt.c:2001:17: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 2001 |                 write(1, "\e[?5l", 5);
      |                 ^~~~~~~~~~~~~~~~~~~~~
mkdir -p bin
cc -g    -o bin/bt src/bt.o
rm src/bt.o
```

The proposed fix call `die` (as it seems to be done in many failure cases), with code 5 (`EIO`, Input/Output error) when bootterm does not manage to properly write the reset escape sequence.