### PR TITLE
Drop subtitle from -V output

### DIFF
--- a/src/bt.c
+++ b/src/bt.c
@@ -70,7 +70,8 @@
 #endif
 
 const char version_str[] =
-	"BootTerm " VERSION " -- the terminal written for users by its users\n"
+	"BootTerm " VERSION "\n"
+	"\n"
 #if defined(TCGETS2) && !defined(NO_TCGETS2)
 	"Built with support for custom baud rates (TCGETS2).\n"
 #endif


### PR DESCRIPTION
This confuses help2man, which expects any of the following:
-  `<version>`
-  `<program> <version>`
-  `<program> - <version>`

The subtitle used here ("the terminal written for users by its users") isn't used anywhere else in the documentation, so drop it entirely. From a quick look around, most pieces of software don't include a description in their --version/-V.